### PR TITLE
コメントアウト削除

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,6 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       
       <% @items.each do |item| %>
         <% if item.image != nil %>
@@ -157,10 +155,9 @@
         <% end %>
       </li>
       <%end%>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+ 
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+
       <% if @items[0].nil? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -180,11 +177,10 @@
         <% end %>
       </li>
       <%end%>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+      
     </ul>
   </div>
-  <%# /商品一覧 %>
+
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
#WHAT

商品一覧表示機能

# WHY

商品を出品した時トップページに商品の画像と商品の詳細を表示させることで、
購入者への販売行動を容易にさせる為。